### PR TITLE
Support no-op repeat uploads.

### DIFF
--- a/lib/dynamodb-client.js
+++ b/lib/dynamodb-client.js
@@ -159,7 +159,7 @@ function DynamoClient(config) {
 
         if (err) {
           if (err.code === 'ConditionalCheckFailedException') {
-            reject(new Error('revision already exists'));
+            resolve();
           } else {
             reject(err);
           }

--- a/node_tests/unit/lib/dynamodb-test.js
+++ b/node_tests/unit/lib/dynamodb-test.js
@@ -118,25 +118,18 @@ describe('DynamoDBAdapter', function() {
         });
     });
 
-    describe('upload failure', function() {
-      var second;
-
-      beforeEach(function() {
-        second = upload
-          .then(function() {
-            return ddbAdapter.upload(DOCUMENT_TO_SAVE, UPLOAD_KEY);
-          });
-      });
-
-      it('rejects when passed key is already in manifest', function(done) {
-        expect(second).to.be.rejected.and.notify(done);
-      });
-
-      it('rejects with a SilentError ember-cli can handle', function(done) {
-        var errorMessage = /revision already exists/;
-        expect(second).to.be.rejectedWith(Error, errorMessage).and.notify(done);
-      });
+    it('is no-op second time upload occurs', function(done) {
+      expect(upload
+        .then(function() {
+          return ddbAdapter.upload(DOCUMENT_TO_SAVE, UPLOAD_KEY);
+        })
+        .then(function() {
+            return ddb.getRevision(UPLOAD_KEY);
+        }))
+        .to.eventually.eq(DOCUMENT_TO_SAVE)
+        .and.notify(done);
     });
+
   });
 
   describe('list/activate', function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-dynamodb",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "ember-cli-deploy plugin for AWS DynamoDB",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-dynamodb",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "ember-cli-deploy plugin for AWS DynamoDB",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Previously, deploying the same revision a second time (or third, fourth, etc)
would result in an error and the deploy process would exit with an error.

Update dynamo-client to resolve as success cases where the key already
exists.

Questions:
- Should this behavior be activated by a configuration flag?
- Should the version update go to `0.3.0` since this is a change in behavior?
