### PR TITLE
Support timestamp & Correct Revision List

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = {
         var dynamoDbClient = this.readConfig('dynamoDbClient');
 
         this.log('Listing revisions');
-        return dynamoDbClient.list(this._makeKey(activationSuffix))
+        return dynamoDbClient.list(this._makeKey(activationSuffix), this._makeKey())
           .then(function(revisions) {
             return { revisions: revisions };
           })
@@ -126,6 +126,7 @@ module.exports = {
       },
 
       _makeKey: function(value) {
+        value = value || '';
         var keyPrefix = this.readConfig('keyPrefix');
         return keyPrefix + ':' + value;
       }

--- a/lib/dynamodb-client.js
+++ b/lib/dynamodb-client.js
@@ -211,7 +211,7 @@ function DynamoClient(config) {
       params.TableName = that._table;
       params.ConsistentRead = true;
       params.FilterExpression = 'attribute_not_exists(head)';
-      params.ProjectionExpression = 'id';
+      params.ProjectionExpression = 'id,created';
       var more = true;
       var list = [];
 
@@ -226,7 +226,10 @@ function DynamoClient(config) {
             } else {
               more = data.LastEvaluatedKey;
               async.each(data.Items, function(item, cback) {
-                list.push(item.id.S);
+                list.push({
+                  revision: item.id.S,
+                  timestamp: parseInt(item.created.N, 10)
+                });
                 cback();
               }, cb);
             }

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -30,7 +30,7 @@ module.exports = CoreObject.extend({
       });
   },
 
-  list: function(currentKey) {
+  list: function(currentKey, keyPrefix) {
     return RSVP.hash({
         revisions: this._list(),
         current: this._current(currentKey)
@@ -40,7 +40,7 @@ module.exports = CoreObject.extend({
         var revisions = results.revisions.map(function(rev) {
           var revision = rev.revision;
           return {
-            revision: revision,
+            revision: keyPrefix ? revision.replace(keyPrefix, '') : revision,
             active: current === revision,
             timestamp: rev.timestamp
           };

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -37,8 +37,13 @@ module.exports = CoreObject.extend({
       })
       .then(function(results) {
         var current = results.current;
-        var revisions = results.revisions.map(function(revision) {
-          return { revision: revision, active: current === revision };
+        var revisions = results.revisions.map(function(rev) {
+          var revision = rev.revision;
+          return {
+            revision: revision,
+            active: current === revision,
+            timestamp: rev.timestamp
+          };
         });
 
         return revisions;
@@ -50,7 +55,10 @@ module.exports = CoreObject.extend({
 
     return this._list()
       .then(function(uploads) {
-        return uploads.indexOf(revisionKey) > -1 ? RSVP.resolve() : RSVP.reject(new Error('revision not found'));
+        var matchingRevision = uploads.find(function(rev) {
+          return rev.revision === revisionKey;
+        });
+        return matchingRevision ? RSVP.resolve() : RSVP.reject(new Error('revision not found'));
       })
       .then(function() {
         return that.ddb.setCurrentRevision(currentKey, revisionKey);

--- a/node_tests/unit/lib/dynamodb-test.js
+++ b/node_tests/unit/lib/dynamodb-test.js
@@ -13,8 +13,9 @@ var expect = chai.expect;
 
 var REVISION_KEY = 'test';
 var DOCUMENT_TO_SAVE = 'Hello';
-var UPLOAD_KEY = 'ember-deploy:' + REVISION_KEY;
-var CURRENT_KEY = 'ember-deploy:current';
+var KEY_PREFIX = 'ember-deploy:';
+var UPLOAD_KEY = KEY_PREFIX + REVISION_KEY;
+var CURRENT_KEY = KEY_PREFIX + 'current';
 var MANIFEST_SIZE = 10;
 
 var cfg = {
@@ -50,7 +51,7 @@ var fillUpManifest = function(uploadCount) {
 };
 
 function listRevisions() {
-  return ddbAdapter.list(CURRENT_KEY);
+  return ddbAdapter.list(CURRENT_KEY, KEY_PREFIX);
 }
 
 describe('DynamoDBAdapter', function() {
@@ -174,7 +175,7 @@ describe('DynamoDBAdapter', function() {
           }
           return expect(activation.then(listRevisions).then(findActive).then(function(results) {
             return results[0];
-          })).to.eventually.include({ revision: UPLOAD_KEY, active: true }).and.has.key('timestamp');
+          })).to.eventually.include({ revision: REVISION_KEY, active: true }).and.has.key('timestamp');
         });
       });
 

--- a/node_tests/unit/lib/dynamodb-test.js
+++ b/node_tests/unit/lib/dynamodb-test.js
@@ -168,12 +168,13 @@ describe('DynamoDBAdapter', function() {
           return expect(activation.then(getCurrentRevision)).to.eventually.eq(UPLOAD_KEY);
         });
 
-        it('lists revisions with current revision marked as active', function() {
+        it('lists revisions with current revision marked as active and the created timestamp', function() {
           function findActive(revisions) {
             return revisions.filter(function(revision) { return revision.active });
           }
-          return expect(activation.then(listRevisions).then(findActive))
-            .to.eventually.eql([{ revision: UPLOAD_KEY, active: true }]);
+          return expect(activation.then(listRevisions).then(findActive).then(function(results) {
+            return results[0];
+          })).to.eventually.include({ revision: UPLOAD_KEY, active: true }).and.has.key('timestamp');
         });
       });
 


### PR DESCRIPTION
This PR does two things:

First, this adds the `created` timestamp when fetching the list of revisions and passes that along to the revisions array as a `timestamp` attribute. This should not be a breaking change. 

Second, this makes the revision displayed in the revisions array show the revision and not the prefix + revision. This is _probably_ a breaking change. 

I'd love for this to get merged and published, but super open to and changes if you have any concerns.

Thanks!!
