### PR TITLE
Optionally support retrieving AWS credentials from standard locations.

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
         }
       },
 
-      requiredConfig: ['accessKeyId', 'secretAccessKey', 'region', 'table', 'indexName'],
+      requiredConfig: ['region', 'table', 'indexName'],
 
       upload: function(context) {
         var filePattern = this.readConfig('filePattern');

--- a/lib/dynamodb-client.js
+++ b/lib/dynamodb-client.js
@@ -5,12 +5,19 @@ var moment = require('moment');
 
 function DynamoClient(config) {
 
-  this._ddb = new AWS.DynamoDB({
+  var dynamoConfig = {
     region: config.region,
-    accessKeyId: config.accessKeyId,
-    secretAccessKey: config.secretAccessKey,
     apiVersion: 'latest'
-  });
+  };
+
+  if (config.hasOwnProperty('accessKeyId')) {
+    dynamoConfig.accessKeyId = config.accessKeyId;
+  }
+  if (config.hasOwnProperty('secretAccessKey')) {
+    dynamoConfig.secretAccessKey = config.secretAccessKey;
+  }
+
+  this._ddb = new AWS.DynamoDB(dynamoConfig);
 
   this._table = config.table;
   this._index = config.indexName;

--- a/node_tests/unit/lib/dynamodb-default-aws-creds-test.js
+++ b/node_tests/unit/lib/dynamodb-default-aws-creds-test.js
@@ -1,0 +1,214 @@
+var CoreObject = require('core-object');
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+var MockUI = require('ember-cli/tests/helpers/mock-ui');
+var SilentError = require('silent-error');
+var RSVP = require('rsvp');
+var AWS = require('aws-sdk');
+var DDB = require('../../../lib/dynamodb-client');
+var DynamoDBAdapter = require('../../../lib/dynamodb');
+
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+
+var REVISION_KEY = 'test';
+var DOCUMENT_TO_SAVE = 'Hello';
+var KEY_PREFIX = 'ember-deploy:';
+var UPLOAD_KEY = KEY_PREFIX + REVISION_KEY;
+var CURRENT_KEY = KEY_PREFIX + 'current';
+var MANIFEST_SIZE = 10;
+
+var cfg = {
+  region: 'us-west-2',
+  table: 'ember-deploy-test',
+  indexName: 'manifest-created-index'
+};
+
+var ddb = new DDB(cfg);
+
+var ddbAdapter;
+var upload;
+
+var cleanUpDDB = function(done) {
+  ddb.clear().then(done).catch(done);
+};
+
+var uploadWithRevisionKey = function(key) {
+  key = key === undefined ? '' : key;
+  return ddbAdapter.upload(DOCUMENT_TO_SAVE, UPLOAD_KEY + key);
+};
+
+var fillUpManifest = function(uploadCount) {
+  var promises = [];
+
+  for (var i = 0; i < uploadCount; i++) {
+    promises.push(uploadWithRevisionKey(i));
+  }
+
+  return RSVP.all(promises);
+};
+
+function listRevisions() {
+  return ddbAdapter.list(CURRENT_KEY, KEY_PREFIX);
+}
+
+describe('DynamoDBAdapter_DefaultAWSCredentials', function() {
+  this.timeout(5000);
+
+  beforeEach(function() {
+
+    ddbAdapter = new DynamoDBAdapter({
+      region: 'us-west-2',
+      table: 'ember-deploy-test',
+      indexName: 'manifest-created-index',
+      manifestSize: MANIFEST_SIZE
+    });
+
+    upload = uploadWithRevisionKey();
+  });
+
+  afterEach(function(done) {
+    cleanUpDDB(done);
+  });
+
+  describe('#upload', function() {
+
+    it('stores passed value in DynamoDB', function(done) {
+      return expect(upload.then(function() {
+        return ddb.getRevision(UPLOAD_KEY);
+      })).to.eventually.eq(DOCUMENT_TO_SAVE).notify(done);
+    });
+
+    it('resolves with the document key on successful upload', function(done) {
+      expect(upload.catch(done)).to.eventually.eq(UPLOAD_KEY).and.notify(done);
+    });
+
+    it('updates a list of recent uploads when upload resolves', function(done) {
+      return upload
+        .then(function() {
+          return ddb.listAll();
+        })
+        .then(function(values) {
+          return expect(values.length).to.be.greaterThan(0);
+        }).finally(done);
+    });
+
+    it('only keeps <manifestSize> uploads in list after upload', function(done) {
+      return expect(upload
+        .then(fillUpManifest.bind(null, MANIFEST_SIZE))
+        .then(function() {
+          return ddb.listAll();
+        })
+        .then(function(values) {
+          return (values) ? values.length : 0;
+        }).catch(function(error) {console.dir(error);})).to.eventually.eq(MANIFEST_SIZE).and.notify(done);
+    });
+
+    it('removes oldest entry', function() {
+      return upload
+        .then(fillUpManifest.bind(null, MANIFEST_SIZE))
+        .then(function() {
+          return ddb.listAll();
+        })
+        .then(function(values) {
+          expect(values).not.to.contain(UPLOAD_KEY);
+        });
+    });
+
+    it('is no-op second time upload occurs', function(done) {
+      expect(upload
+        .then(function() {
+          return ddbAdapter.upload(DOCUMENT_TO_SAVE, UPLOAD_KEY);
+        })
+        .then(function() {
+            return ddb.getRevision(UPLOAD_KEY);
+        }))
+        .to.eventually.eq(DOCUMENT_TO_SAVE)
+        .and.notify(done);
+    });
+
+  });
+
+  describe('list/activate', function() {
+    var uploadsDone;
+
+    beforeEach(function() {
+      uploadsDone = upload
+        .then(fillUpManifest.bind(null, MANIFEST_SIZE-1));
+    });
+
+    describe('#list', function() {
+      it('lists all uploads stored in manifest', function(done) {
+        return expect(uploadsDone
+          .then(listRevisions)
+          .then(function(revisions) {
+            return revisions.length;
+          }).catch(function(error) {console.dir(error)})).to.eventually.eq(MANIFEST_SIZE).and.notify(done);
+      });
+    });
+
+    describe('#activate', function() {
+      var activation;
+
+      describe('successful activation', function() {
+        beforeEach(function() {
+          activation = uploadsDone
+            .then(function() {
+              return ddbAdapter.activate(UPLOAD_KEY, CURRENT_KEY);
+            });
+        });
+
+        it('sets current key when revision key is in manifest', function() {
+          function getCurrentRevision() {
+            return ddb.getRevision(CURRENT_KEY);
+          }
+          return expect(activation.then(getCurrentRevision)).to.eventually.eq(UPLOAD_KEY);
+        });
+
+        it('lists revisions with current revision marked as active and the created timestamp', function() {
+          function findActive(revisions) {
+            return revisions.filter(function(revision) { return revision.active });
+          }
+          return expect(activation.then(listRevisions).then(findActive).then(function(results) {
+            return results[0];
+          })).to.eventually.include({ revision: REVISION_KEY, active: true }).and.has.key('timestamp');
+        });
+      });
+
+      it('rejects when no revision is passed', function() {
+        activation = uploadsDone
+          .then(function() {
+            return ddbAdapter.activate();
+          });
+
+        return expect(activation).to.be.rejectedWith(Error, 'revision not found');
+      });
+
+      it('rejects when key is not in manifest', function() {
+        activation = uploadsDone
+          .then(function() {
+            return ddbAdapter.activate('not-in-manifest');
+          });
+
+        return expect(activation).to.be.rejectedWith(Error, 'revision not found');
+      });
+
+      it('does not set the current revision when key is not in manifest', function() {
+        activation = uploadsDone
+          .then(function() {
+            return ddbAdapter.activate(UPLOAD_KEY, CURRENT_KEY);
+          })
+          .then(function() {
+            return ddbAdapter.activate('does-not-exist');
+          });
+
+        return expect(activation).to.be.rejected
+          .then(function() {
+            return ddbAdapter._current(CURRENT_KEY);
+          }).then(function(currentRevision) {
+            return expect(currentRevision).to.eql(UPLOAD_KEY);
+          });
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-dynamodb",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "ember-cli-deploy plugin for AWS DynamoDB",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
There are several standard locations for AWS credentials, like environment
variables and dotfiles. Previously this plugin ignored those and expected
the user to specify the access & secret key.

Update dynamodb-client.js to use the values set in config, if available,
and if not default to not setting them. Not setting the credentials when
creating the AWS.DynamoDB instance causes the AWS sdk to look for the
credentials in the standard locations, like environment variables, dotfile,
and even ec2 instance profiles.

http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html

Minor version bump to indicate new functionality that is backwards
compatible.